### PR TITLE
SCRUM-116 이전 pr 리뷰 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
         exclude group: 'org.asynchttpclient', module: 'async-http-client'
     }
     implementation 'org.asynchttpclient:async-http-client:3.0.1'
-    implementation 'org.bouncycastle:bcprov-jdk18on:1.78'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.80'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/wellmeet/webpush/WebPushService.java
+++ b/src/main/java/com/wellmeet/webpush/WebPushService.java
@@ -26,10 +26,11 @@ public class WebPushService {
     public SubscribeResponse subscribe(String userId, SubscribeRequest request) {
         List<PushSubscription> existingSubscriptions = pushSubscriptionRepository.findByUserId(userId);
         Optional<PushSubscription> pushSubscription = existingSubscriptions.stream()
-                .filter(subscription -> subscription.isSameEnpPoint(request.endpoint()))
+                .filter(subscription -> subscription.isSameEndpoint(request.endpoint()))
                 .findAny();
         if (pushSubscription.isPresent()) {
             PushSubscription subscription = pushSubscription.get();
+            subscription.update(request.toDomain(userId));
             return new SubscribeResponse(subscription);
         }
         PushSubscription subscription = request.toDomain(userId);

--- a/src/main/java/com/wellmeet/webpush/WebPushService.java
+++ b/src/main/java/com/wellmeet/webpush/WebPushService.java
@@ -7,7 +7,7 @@ import com.wellmeet.webpush.dto.SubscribeRequest;
 import com.wellmeet.webpush.dto.SubscribeResponse;
 import com.wellmeet.webpush.dto.TestPushRequest;
 import com.wellmeet.webpush.dto.UnsubscribeRequest;
-import com.wellmeet.webpush.infrastucture.WebPushSender;
+import com.wellmeet.webpush.infrastructure.WebPushSender;
 import com.wellmeet.webpush.repository.PushSubscriptionRepository;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/wellmeet/webpush/domain/PushSubscription.java
+++ b/src/main/java/com/wellmeet/webpush/domain/PushSubscription.java
@@ -41,7 +41,12 @@ public class PushSubscription extends BaseEntity {
         this.active = true;
     }
 
-    public boolean isSameEnpPoint(String endpoint) {
+    public void update(PushSubscription updatedSubscription) {
+        this.p256dh = updatedSubscription.p256dh;
+        this.auth = updatedSubscription.auth;
+    }
+
+    public boolean isSameEndpoint(String endpoint) {
         return this.endpoint.equals(endpoint);
     }
 }

--- a/src/main/java/com/wellmeet/webpush/infrastructure/WebPushSender.java
+++ b/src/main/java/com/wellmeet/webpush/infrastructure/WebPushSender.java
@@ -1,4 +1,4 @@
-package com.wellmeet.webpush.infrastucture;
+package com.wellmeet.webpush.infrastructure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wellmeet.config.VapidConfig;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=wellmeet-notification

--- a/src/test/java/com/wellmeet/WellmeetNotificationApplicationTests.java
+++ b/src/test/java/com/wellmeet/WellmeetNotificationApplicationTests.java
@@ -2,8 +2,10 @@ package com.wellmeet;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class WellmeetNotificationApplicationTests {
 
     @Test


### PR DESCRIPTION
[SCRUM-116]

https://github.com/Team-soft-macaron/WellMeet-Backend-Notification/pull/2
ai리뷰가 머지된 뒤에 달려서 해당 리뷰 중 반영이 필요한 내용들 반영했습니다.

[SCRUM-116]: https://soft-macaron.atlassian.net/browse/SCRUM-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능/개선
  - 웹 푸시 구독 처리 개선: 동일 엔드포인트 재구독 시 암호화 키가 자동 갱신되어 최신 상태로 유지됩니다.
- 버그 수정
  - 엔드포인트 비교 로직을 바로잡아 중복 구독 식별 정확도를 높였습니다.
- 정리(Refactor)
  - 내부 패키지 경로 오탈자를 정정해 구성 일관성을 개선했습니다.
- 유지보수(Chores)
  - 보안 라이브러리 의존성 업데이트(bcprov 1.78 → 1.80).
  - 기본 애플리케이션 이름 설정을 정리했습니다.
- 테스트
  - 테스트 프로필을 추가하여 테스트 환경 구성을 분리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->